### PR TITLE
Remove unnecessary ppx_type_conv and ppx-tools from opam file

### DIFF
--- a/diet.opam
+++ b/diet.opam
@@ -16,9 +16,7 @@ depends: [
   "result"
   "sexplib"
   "dune" {build}
-  "ppx_tools" {build}
   "ppx_sexp_conv" {build}
-  "ppx_type_conv" {build}
   "ounit" {test}
 ]
 


### PR DESCRIPTION
Signed-off-by: Jon Ludlam <jonathan.ludlam@citrix.com>