### PR TITLE
Use to_string instead of sexps for debugging

### DIFF
--- a/diet.opam
+++ b/diet.opam
@@ -7,9 +7,7 @@ doc: "https://mirage.github.io/ocaml-diet/"
 bug-reports: "https://github.com/mirage/ocaml-diet/issues"
 depends: [
   "ocaml" {>= "4.03.0"}
-  "sexplib"
   "dune" {build}
-  "ppx_sexp_conv"
   "ounit" {with-test}
 ]
 build: [

--- a/fuzz/dune
+++ b/fuzz/dune
@@ -1,5 +1,3 @@
-(executables
- (names fuzz)
- (libraries  diet crowbar)
- (preprocess (pps ppx_sexp_conv))
-)
+(executable
+ (name fuzz)
+ (libraries diet crowbar))

--- a/fuzz/fuzz.ml
+++ b/fuzz/fuzz.ml
@@ -17,14 +17,14 @@
 open Crowbar
 
 module Int = struct
-  open Sexplib.Std
-  type t = int [@@deriving sexp]
+  type t = int
   let compare (x: t) (y: t) = Pervasives.compare x y
   let zero = 0
   let succ x = x + 1
   let pred x = x - 1
   let add x y = x + y
   let sub x y = x - y
+  let to_string = string_of_int
 end
 module IntDiet = Diet.Make(Int)
 
@@ -43,7 +43,7 @@ let diet = fix (fun diet ->
     ]
 )
 
-let pp_diet ppf t = pp ppf "%s" (Sexplib.Sexp.to_string_hum @@ IntDiet.sexp_of_t t)
+let pp_diet = IntDiet.pp
 let diet = with_printer pp_diet diet
 
 (* FIXME: add equals / compare to the diet signature *)

--- a/lib/diet.mli
+++ b/lib/diet.mli
@@ -16,7 +16,7 @@
  *)
 
 module type ELT = sig
-  type t [@@deriving sexp]
+  type t
   (** The type of the set elements. *)
 
   include Set.OrderedType with type t := t
@@ -35,6 +35,9 @@ module type ELT = sig
 
   val add: t -> t -> t
   (** [add a b] returns [a] + [b] *)
+
+  val to_string: t -> string
+  (** Display an element. *)
 end
 
 module type INTERVAL_SET = sig
@@ -57,8 +60,11 @@ module type INTERVAL_SET = sig
     (** the ending element of the interval *)
   end
 
-  type t [@@deriving sexp]
+  type t
   (** The type of sets *)
+
+  val pp: Format.formatter -> t -> unit
+  (** Pretty-print a set *)
 
   val empty: t
   (** The empty set *)

--- a/lib/dune
+++ b/lib/dune
@@ -1,5 +1,3 @@
 (library
- (name        diet)
- (public_name diet)
- (libraries   sexplib)
- (preprocess (pps ppx_sexp_conv)))
+ (name diet)
+ (public_name diet))


### PR DESCRIPTION
Hi,

This removes the dependency to `sexplib` and `ppx_sexp_conv`. It was only required to print error messages to the standard error stream in the test suite.

Instead, this relies on a `to_string` function in the input signature. This maps what can be found in `Int64`, and `Int` in recent versions on the compiler.

As a bonus, a pretty printer is added to the output signature.

Let me know what you think.

Thanks!