### PR TITLE
Move tests to `lib_test`

### DIFF
--- a/lib/diet.ml
+++ b/lib/diet.ml
@@ -602,29 +602,6 @@ module Test = struct
       assert (find_next_gap e set = e)
     done
 
-  let test_printer () =
-    let open IntDiet in
-    let t = add (1, 2) @@ add (4, 5) empty in
-    let got = Format.asprintf "%a" pp t in
-    let expected = {|
-x: 4
-y: 5
-l:
-  x: 1
-  y: 2
-  l:
-    Empty
-  r:
-    Empty
-  h: 1
-  cardinal: 2
-r:
-  Empty
-h: 2
-cardinal: 4|}
-    in
-    assert (String.trim expected = got)
-
   let all = [
     "adding an element to the right", test_add_1;
     "removing an element on the left", test_remove_1;
@@ -636,6 +613,5 @@ cardinal: 4|}
     "diff", test_operator IntSet.diff IntDiet.diff;
     "intersection", test_operator IntSet.inter IntDiet.inter;
     "finding the next gap", test_find_next;
-    "printer", test_printer;
   ]
 end

--- a/lib/diet.ml
+++ b/lib/diet.ml
@@ -310,8 +310,6 @@ let rec node x y l r =
       loop acc from in
     fold range t acc
 
-  let elements t = fold_individual (fun x acc -> x :: acc) t [] |> List.rev
-
   (* iterate over maximal contiguous intervals *)
   let iter f t =
     let f' itl () =
@@ -469,45 +467,4 @@ let rec node x y l r =
     loop empty t n
 
   let check_invariants = Invariant.check
-end
-
-
-module Int = struct
-  type t = int
-  let compare (x: t) (y: t) = Pervasives.compare x y
-  let zero = 0
-  let succ x = x + 1
-  let pred x = x - 1
-  let add x y = x + y
-  let sub x y = x - y
-  let to_string = string_of_int
-end
-module IntDiet = Make(Int)
-module IntSet = Set.Make(Int)
-
-module Test = struct
-
-  let test_add_1 () =
-    let open IntDiet in
-    assert (elements @@ add (3, 4) @@ add (3, 3) empty = [ 3; 4 ])
-
-  let test_remove_1 () =
-    let open IntDiet in
-    assert (elements @@ remove (6, 7) @@ add (7, 8) empty = [ 8 ])
-
-  let test_remove_2 () =
-    let open IntDiet in
-    assert (elements @@ diff (add (9, 9) @@ add (5, 7) empty) (add (7, 9) empty) = [5; 6])
-
-  let test_adjacent_1 () =
-    let open IntDiet in
-    let set = add (9, 9) @@ add (8, 8) empty in
-    IntDiet.Invariant.check set
-
-  let all = [
-    "adding an element to the right", test_add_1;
-    "removing an element on the left", test_remove_1;
-    "removing an elements from two intervals", test_remove_2;
-    "test adjacent intervals are coalesced", test_adjacent_1;
-  ]
 end

--- a/lib/diet.ml
+++ b/lib/diet.ml
@@ -54,6 +54,7 @@ module type INTERVAL_SET = sig
   val inter: t -> t -> t
   val find_next_gap: elt -> t -> elt
   val check_invariants : t -> unit
+  val height : t -> int
 end
 
 
@@ -486,21 +487,6 @@ module IntSet = Set.Make(Int)
 
 module Test = struct
 
-  let check_depth n =
-    let init = IntDiet.add (IntDiet.Interval.make 0 n) IntDiet.empty in
-    (* take away every other block *)
-    let rec sub m acc =
-      (* Printf.printf "acc = %s\n%!" (IntDiet.to_string_internal acc); *)
-      if m <= 0 then acc
-      else sub (m - 2) IntDiet.(remove (Interval.make m m) acc) in
-    let set = sub n init in
-    let d = IntDiet.height set in
-    if d > (int_of_float (log (float_of_int n) /. (log 2.)) + 1)
-    then failwith "Depth larger than expected";
-    let set = sub (n - 1) set in
-    let d = IntDiet.height set in
-    assert (d == 1)
-
   let test_add_1 () =
     let open IntDiet in
     assert (elements @@ add (3, 4) @@ add (3, 3) empty = [ 3; 4 ])
@@ -518,13 +504,10 @@ module Test = struct
     let set = add (9, 9) @@ add (8, 8) empty in
     IntDiet.Invariant.check set
 
-  let test_depth () = check_depth 1048576
-
   let all = [
     "adding an element to the right", test_add_1;
     "removing an element on the left", test_remove_1;
     "removing an elements from two intervals", test_remove_2;
     "test adjacent intervals are coalesced", test_adjacent_1;
-    "logarithmic depth", test_depth;
   ]
 end

--- a/lib/diet.ml
+++ b/lib/diet.ml
@@ -53,6 +53,7 @@ module type INTERVAL_SET = sig
   val diff: t -> t -> t
   val inter: t -> t -> t
   val find_next_gap: elt -> t -> elt
+  val check_invariants : t -> unit
 end
 
 
@@ -466,6 +467,7 @@ let rec node x y l r =
       end in
     loop empty t n
 
+  let check_invariants = Invariant.check
 end
 
 
@@ -597,6 +599,5 @@ module Test = struct
     "adding and removing elements acts like a Set", test_adds;
     "union", test_operator IntSet.union IntDiet.union;
     "diff", test_operator IntSet.diff IntDiet.diff;
-    "intersection", test_operator IntSet.inter IntDiet.inter;
   ]
 end

--- a/lib/diet.ml
+++ b/lib/diet.ml
@@ -588,20 +588,6 @@ module Test = struct
 
   let test_depth () = check_depth 1048576
 
-  let test_find_next () =
-    let open IntDiet in
-    let set = add (9, 9) @@ add (5, 7) empty in
-    assert (find_next_gap 0 set = 0);
-    assert (find_next_gap 5 set = 8);
-    assert (find_next_gap 9 set = 10);
-    for i = 0 to 12 do
-      let e = find_next_gap i set in
-      assert (e >= i);
-      assert (not @@ mem e set);
-      assert (e == i || mem i set);
-      assert (find_next_gap e set = e)
-    done
-
   let all = [
     "adding an element to the right", test_add_1;
     "removing an element on the left", test_remove_1;
@@ -612,6 +598,5 @@ module Test = struct
     "union", test_operator IntSet.union IntDiet.union;
     "diff", test_operator IntSet.diff IntDiet.diff;
     "intersection", test_operator IntSet.inter IntDiet.inter;
-    "finding the next gap", test_find_next;
   ]
 end

--- a/lib/diet.ml
+++ b/lib/diet.ml
@@ -555,22 +555,6 @@ module Test = struct
       check_equals set diet;
     done
 
-  let test_operator set_op diet_op () =
-    for _ = 1 to 100 do
-      let set1, diet1 = make_random 1000 1000 in
-      let set2, diet2 = make_random 1000 1000 in
-      check_equals set1 diet1;
-      check_equals set2 diet2;
-      let set3 = set_op set1 set2 in
-      let diet3 = diet_op diet1 diet2 in
-      (*
-      Printf.fprintf stderr "diet1 = %s\n" (IntDiet.to_string_internal diet1);
-      Printf.fprintf stderr "diet3 = %s\n" (IntDiet.to_string_internal diet2);
-      Printf.fprintf stderr "diet2 = %s\n" (IntDiet.to_string_internal diet3);
-      *)
-      check_equals set3 diet3
-    done
-
   let test_add_1 () =
     let open IntDiet in
     assert (elements @@ add (3, 4) @@ add (3, 3) empty = [ 3; 4 ])
@@ -597,7 +581,5 @@ module Test = struct
     "test adjacent intervals are coalesced", test_adjacent_1;
     "logarithmic depth", test_depth;
     "adding and removing elements acts like a Set", test_adds;
-    "union", test_operator IntSet.union IntDiet.union;
-    "diff", test_operator IntSet.diff IntDiet.diff;
   ]
 end

--- a/lib/diet.ml
+++ b/lib/diet.ml
@@ -501,60 +501,6 @@ module Test = struct
     let d = IntDiet.height set in
     assert (d == 1)
 
-  let make_random n m =
-    let rec loop set diet = function
-      | 0 -> set, diet
-      | m ->
-        let r = Random.int n in
-        let r' = Random.int (n - r) + r in
-        let add = Random.bool () in
-        let rec range from upto =
-          if from > upto then [] else from :: (range (from + 1) upto) in
-        let set = List.fold_left (fun set elt -> (if add then IntSet.add else IntSet.remove) elt set) set (range r r') in
-        let diet' = (if add then IntDiet.add else IntDiet.remove) (IntDiet.Interval.make r r') diet in
-        begin
-          try
-            IntDiet.Invariant.check diet';
-          with e ->
-            Printf.fprintf stderr "%s %d\nBefore: %s\nAfter: %s\n"
-              (if add then "Add" else "Remove") r
-              (IntDiet.to_string_internal diet) (IntDiet.to_string_internal diet');
-            raise e
-        end;
-        loop set diet' (m - 1) in
-    loop IntSet.empty IntDiet.empty m
-    (*
-  let set_to_string set =
-    String.concat "; " @@ List.map string_of_int @@ IntSet.elements set
-  let diet_to_string diet =
-    String.concat "; " @@ List.map string_of_int @@ IntDiet.elements diet
-    *)
-  let check_equals set diet =
-    let set' = IntSet.elements set in
-    let diet' = IntDiet.elements diet in
-    if set' <> diet' then begin
-      (*
-      Printf.fprintf stderr "Set contains: [ %s ]\n" @@ set_to_string set;
-      Printf.fprintf stderr "Diet contains: [ %s ]\n" @@ diet_to_string diet;
-      *)
-      failwith "check_equals"
-    end
-
-  let test_adds () =
-    for _ = 1 to 100 do
-      let set, diet = make_random 1000 1000 in
-      begin
-        try
-          IntDiet.Invariant.check diet
-        with e ->
-          (*
-          Printf.fprintf stderr "Diet contains: [ %s ]\n" @@ IntDiet.to_string_internal diet;
-          *)
-          raise e
-      end;
-      check_equals set diet;
-    done
-
   let test_add_1 () =
     let open IntDiet in
     assert (elements @@ add (3, 4) @@ add (3, 3) empty = [ 3; 4 ])
@@ -580,6 +526,5 @@ module Test = struct
     "removing an elements from two intervals", test_remove_2;
     "test adjacent intervals are coalesced", test_adjacent_1;
     "logarithmic depth", test_depth;
-    "adding and removing elements acts like a Set", test_adds;
   ]
 end

--- a/lib/diet.mli
+++ b/lib/diet.mli
@@ -125,6 +125,9 @@ module type INTERVAL_SET = sig
 
   val check_invariants : t -> unit
   (** Check that underlying invariants hold. *)
+
+  val height : t -> int
+  (** [height t] return the height of the corresponding tree. *)
 end
 
 

--- a/lib/diet.mli
+++ b/lib/diet.mli
@@ -123,8 +123,9 @@ module type INTERVAL_SET = sig
 
   (**/**)
 
-  val check_invariants : t -> unit
-  (** Check that underlying invariants hold. *)
+  val check_invariants : t -> (unit, string) result
+  (** [check_invariants t] returns [Ok ()] if the underlying invariants hold, or
+      an error message. *)
 
   val height : t -> int
   (** [height t] return the height of the corresponding tree. *)

--- a/lib/diet.mli
+++ b/lib/diet.mli
@@ -132,7 +132,3 @@ end
 
 
 module Make(Elt: ELT): INTERVAL_SET with type elt = Elt.t
-
-module Test: sig
-  val all: (string * (unit -> unit)) list
-end

--- a/lib/diet.mli
+++ b/lib/diet.mli
@@ -120,6 +120,11 @@ module type INTERVAL_SET = sig
   val find_next_gap: elt -> t -> elt
   (** [find_next_gap from t] returns the next element that's
       absent in set [t] and greater than or equal to [from] **)
+
+  (**/**)
+
+  val check_invariants : t -> unit
+  (** Check that underlying invariants hold. *)
 end
 
 

--- a/lib_test/test.ml
+++ b/lib_test/test.ml
@@ -13,9 +13,12 @@
  * OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
  * PERFORMANCE OF THIS SOFTWARE.
  *)
-open OUnit
+open OUnit2
 
-let _ =
-  let diet_tests = List.map (fun (name, fn) -> name >:: fn) Diet.Test.all in
-  let suite = "diet" >::: diet_tests in
-  OUnit2.run_test_tt_main (ounit2_of_ounit1 suite)
+let suite =
+  "diet" >:::
+  List.map
+    (fun (name, fn) -> name >:: (fun _ctx -> fn ()))
+    Diet.Test.all
+
+let () = run_test_tt_main suite

--- a/lib_test/test.ml
+++ b/lib_test/test.ml
@@ -126,6 +126,22 @@ let test_operators ops ctxt =
       ) ops
   done
 
+let test_depth ctxt =
+  let n = 0x100000 in
+  let init = IntDiet.add (0, n) IntDiet.empty in
+  (* take away every other block *)
+  let rec sub m acc =
+    if m <= 0 then acc
+    else sub (m - 2) (IntDiet.remove (m, m) acc) in
+  let set = sub n init in
+  let d = IntDiet.height set in
+  let bound = int_of_float (log (float_of_int n) /. (log 2.)) + 1 in
+  assert_bool "Depth lower than bound" (d <= bound);
+  let set = sub (n - 1) set in
+  let got = IntDiet.height set in
+  let expected = 1 in
+  assert_equal ~ctxt ~printer:string_of_int expected got
+
 let suite =
   "diet" >:::
   (
@@ -133,7 +149,8 @@ let suite =
     (fun (name, fn) -> name >:: (fun _ctx -> fn ()))
     Diet.Test.all
   @
-  [ "operators" >:: test_operators
+  [ "logarithmic depth" >:: test_depth
+  ; "operators" >:: test_operators
     [ ("union", IntSet.union, IntDiet.union)
     ; ("diff", IntSet.diff, IntDiet.diff)
     ; ("intersection", IntSet.inter, IntDiet.inter)

--- a/lib_test/test.ml
+++ b/lib_test/test.ml
@@ -81,6 +81,16 @@ let test_find_next_gap ctxt =
     assert (find_next_gap e set = e)
   done
 
+
+let check_invariants_ok diet =
+  let expected = Ok () in
+  let got = IntDiet.check_invariants diet in
+  let printer = function
+    | Ok () -> "no error"
+    | Error e -> e
+  in
+  assert_equal ~printer expected got
+
 let make_random n m =
   let rec loop set diet = function
     | 0 -> set, diet
@@ -92,15 +102,7 @@ let make_random n m =
         if from > upto then [] else from :: (range (from + 1) upto) in
       let set = List.fold_left (fun set elt -> (if add then IntSet.add else IntSet.remove) elt set) set (range r r') in
       let diet' = (if add then IntDiet.add else IntDiet.remove) (r, r') diet in
-      begin
-        try
-          IntDiet.check_invariants diet'
-        with e ->
-          Format.eprintf "%s %d\nBefore: %a\nAfter: %a\n"
-            (if add then "Add" else "Remove") r
-            IntDiet.pp diet IntDiet.pp diet';
-          raise e
-      end;
+      check_invariants_ok diet';
       loop set diet' (m - 1) in
   loop IntSet.empty IntDiet.empty m
 
@@ -168,7 +170,7 @@ let test_remove_2 ctxt =
 let test_adjacent_1 _ctxt =
   let open IntDiet in
   let set = add (9, 9) @@ add (8, 8) empty in
-  check_invariants set
+  check_invariants_ok set
 
 let suite =
   "diet" >:::

--- a/lib_test/test.ml
+++ b/lib_test/test.ml
@@ -56,6 +56,24 @@ cardinal: 4|}
   in
   assert_equal ~ctxt ~printer:(fun s -> s) ~cmp:String.equal expected got
 
+let test_find_next_gap ctxt =
+  let open IntDiet in
+  let set = add (9, 9) @@ add (5, 7) empty in
+  let test n ~expected =
+    let got = find_next_gap n set in
+    assert_equal ~ctxt ~printer:string_of_int expected got
+  in
+  test 0 ~expected:0;
+  test 5 ~expected:8;
+  test 9 ~expected:10;
+  for i = 0 to 12 do
+    let e = find_next_gap i set in
+    assert (e >= i);
+    assert (not @@ mem e set);
+    assert (e == i || mem i set);
+    assert (find_next_gap e set = e)
+  done
+
 let suite =
   "diet" >:::
   (
@@ -63,7 +81,8 @@ let suite =
     (fun (name, fn) -> name >:: (fun _ctx -> fn ()))
     Diet.Test.all
   @
-  [ "printer" >:: test_printer
+  [ "finding the next gap" >:: test_find_next_gap
+  ; "printer" >:: test_printer
   ]
   )
 


### PR DESCRIPTION
See #12.

This moves the test code to `lib_test` instead of having it in the main module. Visible changes:

- the test suite is about 10% faster due to some duplicate checks removed
- better error messages are printed in error cases (commented log code is replaced by ounit2 assertions)
- two extra functions are added to the functor output: `check_invariants` and `height` but they are hidden behind a `(**/**)`