### PR TITLE
Compare and Equal

### DIFF
--- a/bench/bench.ml
+++ b/bench/bench.ml
@@ -12,10 +12,7 @@ module IntDiet = Diet.Make(struct
     let to_string = string_of_int
   end)
 
-(** This fix state ensures that the benchmarks are reproducible.
-    Those constants have been generated using [Random.int 1_073_741_823].
-*)
-let state = Random.State.make [|994326685; 290180182; 366831641|]
+let state = Random.State.make_self_init ()
 
 let fisher_yates_shuffle a =
   for i = Array.length a-1 downto 1 do

--- a/bench/bench.ml
+++ b/bench/bench.ml
@@ -17,7 +17,7 @@ module IntDiet = Diet.Make(struct
 *)
 let state = Random.State.make [|994326685; 290180182; 366831641|]
 
-let shuffle a =
+let fisher_yates_shuffle a =
   for i = Array.length a-1 downto 1 do
     let j = Random.State.int state (i + 1) in
     let tmp = a.(i) in
@@ -41,7 +41,7 @@ let diet_from_array arr =
 let gen_diets n =
   let intervals = gen_array n in
   let regular = diet_from_array intervals in
-  shuffle intervals;
+  fisher_yates_shuffle intervals;
   let shuffled = diet_from_array intervals in
   let different = diet_from_array (gen_array n) in
   regular, shuffled, different

--- a/bench/bench.ml
+++ b/bench/bench.ml
@@ -1,0 +1,59 @@
+open Core
+open Core_bench.Std
+
+module IntDiet = Diet.Make(struct
+    type t = int
+    let compare (x: t) (y: t) = Pervasives.compare x y
+    let zero = 0
+    let succ x = x + 1
+    let pred x = x - 1
+    let add x y = x + y
+    let sub x y = x - y
+    let to_string = string_of_int
+  end)
+
+let state = Random.State.make [|994326685; 290180182; 366831641|]
+
+let shuffle a =
+  for i = Array.length a-1 downto 1 do
+    let j = Random.State.int state (i + 1) in
+    let tmp = a.(i) in
+    a.(i) <- a.(j);
+    a.(j) <- tmp;
+  done
+
+let gen_array size =
+  let gen_interval i =
+    let length = Random.State.int state 8 in
+    IntDiet.Interval.make (10 * i) (10 * i + length)
+  in
+  Array.init size ~f:gen_interval
+
+let diet_from_array arr =
+  Array.fold
+    ~init:IntDiet.empty
+    ~f:(fun diet intvl -> IntDiet.add intvl diet)
+    arr
+
+let gen_diets n =
+  let intervals = gen_array n in
+  let regular = diet_from_array intervals in
+  shuffle intervals;
+  let shuffled = diet_from_array intervals in
+  let different = diet_from_array (gen_array n) in
+  regular, shuffled, different
+
+let d10, d10', e10 = gen_diets 10
+let d100, d100', e100 = gen_diets 100
+let d1000, d1000', e1000 = gen_diets 1000
+
+let () =
+  Command.run
+    (Bench.make_command
+       [ Bench.Test.create ~name:"Equal (size 10)" (fun () -> ignore @@ IntDiet.equal d10 d10')
+       ; Bench.Test.create ~name:"Equal (size 100)" (fun () -> ignore @@ IntDiet.equal d100 d100')
+       ; Bench.Test.create ~name:"Equal (size 1000)" (fun () -> ignore @@ IntDiet.equal d1000 d1000')
+       ; Bench.Test.create ~name:"Not equal (size 10)" (fun () -> ignore @@ IntDiet.equal d10 e10)
+       ; Bench.Test.create ~name:"Not equal (size 100)" (fun () -> ignore @@ IntDiet.equal d100 e100)
+       ; Bench.Test.create ~name:"Not equal (size 1000)" (fun () -> ignore @@ IntDiet.equal d1000 e1000)
+       ])

--- a/bench/bench.ml
+++ b/bench/bench.ml
@@ -12,6 +12,9 @@ module IntDiet = Diet.Make(struct
     let to_string = string_of_int
   end)
 
+(** This fix state ensures that the benchmarks are reproducible.
+    Those constants have been generated using [Random.int 1_073_741_823].
+*)
 let state = Random.State.make [|994326685; 290180182; 366831641|]
 
 let shuffle a =

--- a/bench/dune
+++ b/bench/dune
@@ -1,0 +1,13 @@
+(executable
+  (name bench)
+  (libraries
+    core
+    core_bench
+    diet
+  )
+)
+
+(alias
+  (name bench)
+  (action (run ./bench.exe))
+)

--- a/fuzz/fuzz.ml
+++ b/fuzz/fuzz.ml
@@ -51,6 +51,25 @@ let eq a b =
   let intervals t = IntDiet.fold (fun x acc -> x :: acc) t [] |> List.rev in
   intervals a = (intervals b)
 
+let shuffle_a st a =
+  for i = Array.length a-1 downto 1 do
+    let j = Random.State.int st (i+1) in
+    let tmp = a.(i) in
+    a.(i) <- a.(j);
+    a.(j) <- tmp;
+  done
+
+let check_equality interval_list rng_state =
+  let state = Random.State.make (Array.of_list rng_state) in
+  let interval_array = Array.of_list interval_list in
+  let diet_of_array array =
+    Array.fold_left (fun diet interval -> IntDiet.add interval diet) IntDiet.empty array
+  in
+  let diet1 = diet_of_array interval_array in
+  shuffle_a state interval_array;
+  let diet2 = diet_of_array interval_array in
+  check (IntDiet.equal diet2 diet1)
+
 let () =
   add_test ~name:"union is commutative" [diet; diet]
     (fun d1 d2 ->
@@ -70,4 +89,5 @@ let () =
   add_test ~name:"distributive 2" [diet; diet; diet]
     (fun d1 d2 d3 ->
        check_eq ~pp:pp_diet ~eq IntDiet.(inter d1 (union d2 d3)) IntDiet.(union (inter d1 d2) (inter d1 d3)));
+  add_test ~name:"equality" [list1 interval; list1 int] check_equality;
   ()

--- a/lib/diet.ml
+++ b/lib/diet.ml
@@ -90,29 +90,27 @@ module Make(Elt: ELT) = struct
     | Node: node -> t
   and node = { x: elt; y: elt; l: t; r: t; h: int; cardinal: elt }
 
-  type enum = End | More of interval * t * enum
-
   let rec cons_enum t enum =
     match t with
     | Empty -> enum
-    | Node {x; y; l; r; _} -> cons_enum l (More ((x, y), r, enum))
+    | Node ({l; _} as node) -> cons_enum l (node::enum)
 
-  let compare_with_invariant (x, y) (x', y') =
+  let compare_with_invariant {x; y; _} {x = x'; y = y'; _} =
     if eq x x' && eq y y' then 0
     else if y < x' then -1
     else 1
 
   let rec compare_aux enum enum' =
     match enum, enum' with
-    | End, End -> 0
-    | End, _ -> -1
-    | _, End -> 1
-    | More (interval, r, enum), More (interval', r', enum') ->
-      (match compare_with_invariant interval interval' with
-       | 0 -> compare_aux (cons_enum r enum) (cons_enum r' enum')
+    | [], [] -> 0
+    | [], _ -> -1
+    | _, [] -> 1
+    | node::enum, node'::enum' ->
+      (match compare_with_invariant node node' with
+       | 0 -> compare_aux (cons_enum node.r enum) (cons_enum node'.r enum')
        | c -> c)
 
-  let compare t t' = compare_aux (cons_enum t End) (cons_enum t' End)
+  let compare t t' = compare_aux (cons_enum t []) (cons_enum t' [])
 
   let equal t t' = compare t t' = 0
 

--- a/lib/diet.mli
+++ b/lib/diet.mli
@@ -63,6 +63,12 @@ module type INTERVAL_SET = sig
   type t
   (** The type of sets *)
 
+  val equal : t -> t -> bool
+  (** Equality over sets *)
+
+  val compare : t -> t -> int
+  (** Comparison over sets *)
+
   val pp: Format.formatter -> t -> unit
   (** Pretty-print a set *)
 

--- a/lib_test/test.ml
+++ b/lib_test/test.ml
@@ -172,6 +172,33 @@ let test_adjacent_1 _ctxt =
   let set = add (9, 9) @@ add (8, 8) empty in
   check_invariants_ok set
 
+let test_equal =
+  let open IntDiet in
+  let make l = List.fold_left (fun diet intvl -> add intvl diet) empty l in
+  let test ~nodes ~nodes' ~expected ctxt =
+    let diet = make nodes in
+    let diet' = make nodes' in
+    assert_equal ~ctxt expected (IntDiet.equal diet diet')
+  in
+  [ "Empty" >:: test ~nodes:[] ~nodes':[] ~expected:true
+  ; "Single node" >:: test ~nodes:[(1, 2)] ~nodes':[(1, 2)] ~expected:true
+  ; "Two nodes swapped" >:: test ~nodes:[(1, 2); (4, 5)] ~nodes':[(4, 5); (1, 2)] ~expected:true
+  ; "Swapped nodes 1" >:: test
+      ~nodes:[(7, 8); (1, 2); (10, 11); (4, 5); (13, 14)]
+      ~nodes':[(7, 8); (4, 5); (13, 14); (1, 2); (10, 11)]
+      ~expected:true
+  ; "Swapped nodes 2" >:: test
+      ~nodes:[(4, 5); (1, 2); (10, 11); (7, 8)]
+      ~nodes':[(7, 8); (4, 5); (10, 11); (1, 2)]
+      ~expected:true
+  ; "Swapped nodes 3" >:: test
+      ~nodes:[(7, 8); (4, 5); (1, 2)]
+      ~nodes':[(1, 2); (7, 8); (4, 5)]
+      ~expected:true
+  ; "Non-empty and empty" >:: test ~nodes:[(1, 2)] ~nodes':[] ~expected:false
+  ; "Different roots" >:: test ~nodes:[(1, 2)] ~nodes':[(4, 5)] ~expected:false
+  ]
+
 let suite =
   "diet" >:::
   [ "adding an element to the right" >:: test_add_1
@@ -186,6 +213,7 @@ let suite =
     ]
   ; "finding the next gap" >:: test_find_next_gap
   ; "printer" >:: test_printer
+  ; "equality" >::: test_equal
   ]
 
 let () = run_test_tt_main suite


### PR DESCRIPTION
Fixes #7 

This PR adds `compare` and `equal` functions.

Implementation is the same as stdlib's `Set.compare`. Due to the stronger invariants in DIET, I think it might be possible to optimize it further by traversing both trees and stopping if two incompatible intervals (ie which intersect or whose bounds are adjacent) are met but I felt like this was a good enough first version.

I added a few tests as well as a fuzz check and some benchmarks.

Here are the benchmarks results with a naive pair of folds and a `List.equal`:
```
$ dune exec -- bench/bench.exe -quota 5s
Estimated testing time 30s (6 benchmarks x 5s). Change using '-quota'.
┌───────────────────────┬─────────────┬────────────┬──────────┬──────────┬────────────┐
│ Name                  │    Time/Run │    mWd/Run │ mjWd/Run │ Prom/Run │ Percentage │
├───────────────────────┼─────────────┼────────────┼──────────┼──────────┼────────────┤
│ Equal (size 10)       │    290.16ns │    120.00w │          │          │      0.80% │
│ Equal (size 100)      │  2_843.26ns │  1_200.03w │    2.75w │    2.75w │      7.79% │
│ Equal (size 1000)     │ 36_488.74ns │ 12_000.28w │  279.07w │  279.07w │    100.00% │
│ Not equal (size 10)   │    169.39ns │    120.00w │          │          │      0.46% │
│ Not equal (size 100)  │  1_635.65ns │  1_200.03w │    2.74w │    2.74w │      4.48% │
│ Not equal (size 1000) │ 22_713.03ns │ 12_000.28w │  278.92w │  278.92w │     62.25% │
└───────────────────────┴─────────────┴────────────┴──────────┴──────────┴────────────┘
```
and here the results with the actual `equal`:
```
$ dune exec -- bench/bench.exe -quota 5s
Estimated testing time 30s (6 benchmarks x 5s). Change using '-quota'.
┌───────────────────────┬─────────────┬────────────┬──────────┬──────────┬────────────┐
│ Name                  │    Time/Run │    mWd/Run │ mjWd/Run │ Prom/Run │ Percentage │
├───────────────────────┼─────────────┼────────────┼──────────┼──────────┼────────────┤
│ Equal (size 10)       │    245.14ns │    140.01w │          │          │      0.76% │
│ Equal (size 100)      │  2_471.80ns │  1_400.07w │    0.23w │    0.23w │      7.70% │
│ Equal (size 1000)     │ 32_084.88ns │ 14_000.75w │    3.37w │    3.37w │    100.00% │
│ Not equal (size 10)   │     92.12ns │     56.00w │          │          │      0.29% │
│ Not equal (size 100)  │     86.83ns │     98.01w │          │          │      0.27% │
│ Not equal (size 1000) │    113.15ns │    140.01w │          │          │      0.35% │
└───────────────────────┴─────────────┴────────────┴──────────┴──────────┴────────────┘
```

Let me know what you think!