### PR TITLE
README: Update links, use SVG badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,10 @@
 Ocaml Discrete Interval Encoding Trees
 ======================================
 
-[![Build Status](https://travis-ci.org/djs55/ocaml-diet.png?branch=master)](https://travis-ci.org/djs55/ocaml-diet) [![Coverage Status](https://coveralls.io/repos/djs55/ocaml-diet/badge.png?branch=master)](https://coveralls.io/r/djs55/ocaml-diet?branch=master)
+[![Build Status](https://travis-ci.org/mirage/ocaml-diet.svg?branch=master)](https://travis-ci.org/mirage/ocaml-diet) [![Coverage Status](https://coveralls.io/repos/github/mirage/ocaml-diet/badge.svg?branch=master)](https://coveralls.io/github/mirage/ocaml-diet?branch=master)
 
-Please read [the API documentation](https://djs55.github.io/ocaml-diet/).
+Please read [the API documentation](https://mirage.github.io/ocaml-diet/).
 
 This is based on the
 [Functional Pearls: Diets for Fat Sets](https://web.engr.oregonstate.edu/~erwig/papers/Diet_JFP98.pdf)
 by Martin Erwig.
-


### PR DESCRIPTION
The repo URLs are now accurate, although the Coveralls badge/link still looks broken, probably because it's not set up yet.